### PR TITLE
Strict typing

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,3 @@
+{
+    "languageMode": "strict"
+}

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,3 +1,3 @@
 [tools]
-wally = "UpliftGames/wally@0.3.1"
-rojo = "rojo-rbx/rojo@7.2.1"
+wally = "UpliftGames/wally@0.3.2"
+rojo = "rojo-rbx/rojo@7.4.4"

--- a/src/Instance.luau
+++ b/src/Instance.luau
@@ -2,6 +2,8 @@ local Types = require(script.Parent.Types)
 
 type Cleanup = Types.Cleanup
 type Handler<T...> = Types.Handler<T...>
+type Signal<S, C, T...> = Types.Signal<S, C, T...>
+type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Parent.Signal)
 local ObserveAddedRemovedSignals = Signal.AddedRemovedSignals
@@ -22,10 +24,10 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
     local cleanup = nil
 
     if child then
-        (fn :: any)(child)
+        fn(child)
     end
 
-    local function onChildAdded(added)
+    local function onChildAdded(added: Instance)
         -- If there is already a currently observed child, we don't need to do anything.
         if child then
             return
@@ -33,10 +35,10 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
 
         -- Store the current child, call the associated function, and store the cleanup function.
         child = added
-        cleanup = (fn :: any)(added)
+        cleanup = fn(added)
     end
 
-    local function onChildRemoved(removed)
+    local function onChildRemoved(removed: Instance)
         -- If the removed child is not the currently observed child, it can be safely ignored.
         if removed ~= child then
             return
@@ -57,7 +59,7 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
         -- If there is another child, handle it the same way as if it was added.
         if foundChild then
             child = foundChild
-            cleanup = (fn :: any)(foundChild)
+            cleanup = fn(foundChild)
         end
     end
 
@@ -81,7 +83,7 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveChildren(instance: Instance, fn: Handler<Instance>): Cleanup
-    return ObserveAddedRemovedSignals(instance:GetChildren(), instance.ChildAdded, instance.ChildRemoved, fn)
+    return ObserveAddedRemovedSignals(instance:GetChildren(), instance.ChildAdded :: RBXSignal<Instance>, instance.ChildRemoved :: RBXSignal<Instance>, fn)
 end
 
 --[=[
@@ -91,7 +93,7 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveDescendants(instance: Instance, fn: Handler<Instance>): Cleanup
-    return ObserveAddedRemovedSignals(instance:GetDescendants(), instance.DescendantAdded, instance.DescendantRemoving, fn)
+    return ObserveAddedRemovedSignals(instance:GetDescendants(), instance.DescendantAdded :: RBXSignal<Instance>, instance.DescendantRemoving :: RBXSignal<Instance>, fn)
 end
 
 --[=[
@@ -103,14 +105,14 @@ end
     Note: If the property is not a valid property of the instance, this will throw an error.
 ]=]
 local function ObserveProperty<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = (fn :: any)(instance[name] :: T)
+    local cleanup = fn((instance :: any)[name])
 
     local function onChanged()
         if cleanup then
             cleanup()
         end
 
-        cleanup = (fn :: any)(instance[name] :: T)
+        cleanup = fn((instance :: any)[name])
     end
 
     local connection = instance:GetPropertyChangedSignal(name):Connect(onChanged)
@@ -131,14 +133,14 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveAttribute<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = (fn :: any)(instance:GetAttribute(name) :: T)
+    local cleanup = fn(instance:GetAttribute(name) :: T)
 
     local function onChanged()
         if cleanup then
             cleanup()
         end
 
-        cleanup = (fn :: any)(instance:GetAttribute(name) :: T)
+        cleanup = fn(instance:GetAttribute(name) :: T)
     end
 
     local connection = instance:GetAttributeChangedSignal(name):Connect(onChanged)

--- a/src/Player.luau
+++ b/src/Player.luau
@@ -4,6 +4,7 @@ local Types = require(script.Parent.Types)
 
 type Cleanup = Types.Cleanup
 type Handler<T...> = Types.Handler<T...>
+type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Parent.Signal)
 local ObserveSetClearSignals = Signal.SetClearSignals
@@ -26,8 +27,8 @@ end
 
     Observe the character of a given player
 ]=]
-local function ObserveCharacter(player: Player, fn: Handler<Model>): Cleanup
-    return ObserveSetClearSignals(player.Character, player.CharacterAdded, player.CharacterRemoving, fn)
+local function ObserveCharacter(player: Player, fn: Handler<Model?>): Cleanup
+    return ObserveSetClearSignals(player.Character, player.CharacterAdded :: RBXSignal<Model>, player.CharacterRemoving :: RBXSignal<Model>, fn)
 end
 
 --[=[
@@ -36,10 +37,10 @@ end
 
     Observe all player character pairs in the game.
 ]=]
-local function ObservePlayerCharacters(fn: Handler<Player, Model>): Cleanup
+local function ObservePlayerCharacters(fn: Handler<Player, Model?>): Cleanup
     return ObservePlayers(function(player: Player)
-        return ObserveCharacter(player, function(character: Model)
-            return (fn :: any)(player, character)
+        return ObserveCharacter(player, function(character: Model?)
+            return fn(player, character)
         end)
     end)
 end

--- a/src/Signal.luau
+++ b/src/Signal.luau
@@ -4,13 +4,13 @@ type Cleanup = Types.Cleanup
 type Handler<T> = Types.Handler<T>
 type Callback<T> = Types.Callback<T>
 
-type Signal<T...> = Types.Signal<T...>
-type Connection = Types.Connection
+type Signal<S, C, T...> = Types.Signal<S, C, T...>
+type Connection<C> = Types.Connection<C>
 
 --[=[
     Observe a signal and call a handler with whatever value the signal passes to it.
 ]=]
-local function ObserveChangedSignal<T>(value: T, changed: Signal<T>, fn: Handler<T>): Cleanup
+local function ObserveChangedSignal<S, C, T>(value: T, changed: Signal<S, C, T>, fn: Handler<T>): Cleanup
     -- Initially call the handler with the current value
     local cleanup = fn(value)
 
@@ -18,7 +18,7 @@ local function ObserveChangedSignal<T>(value: T, changed: Signal<T>, fn: Handler
         if cleanup then
             cleanup()
         end
-        
+
         cleanup = fn(newValue)
     end
 
@@ -38,7 +38,7 @@ end
     If the clear signal is fired, the handler will be called with nil.
 ]=]
 
-local function ObserveSetClearSignals<T>(value: T, set: Signal<T>, clear: Signal<any>, fn: Handler<T?>): Cleanup
+local function ObserveSetClearSignals<S1, C1, S2, C2, T>(value: T, set: Signal<S1, C1, T>, clear: Signal<S2, C2>, fn: Handler<T?>): Cleanup
     -- Initially call the handler with the current value
     local cleanup = fn(value)
 
@@ -46,7 +46,7 @@ local function ObserveSetClearSignals<T>(value: T, set: Signal<T>, clear: Signal
         if cleanup then
             cleanup()
         end
-        
+
         cleanup = fn(newValue)
     end
 
@@ -76,15 +76,19 @@ end
     The handler will be called with all values that are added.
     When a value is removed, the associated cleanup will be called.
 ]=]
-function ObserveAddedRemovedSignals<T>(values: {T}, added: Signal<T>, removed: Signal<T>, fn: Handler<T>): Cleanup
-    local cleanups = {}
+function ObserveAddedRemovedSignals<S1, C1, S2, C2, T>(values: {T}, added: Signal<S1, C1, T>, removed: Signal<S2, C2, T>, fn: Handler<T>): Cleanup
+    local cleanups: { [T]: Cleanup } = {}
 
     local function onAdded(value)
         if cleanups[value] then
             return
         end
 
-        cleanups[value] = fn(value)
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        end
     end
 
     local function onRemoved(value)
@@ -98,7 +102,11 @@ function ObserveAddedRemovedSignals<T>(values: {T}, added: Signal<T>, removed: S
 
     -- Initially call the handler with each current value
     for _, value in values do
-        cleanups[value] = fn(value)
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        end
     end
 
     -- Connect the signals

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -5,14 +5,14 @@ export type Callback<T...> = (T...) -> ()
 export type Handler<T...> = (T...) -> Cleanup?
 
 -- Trait Types
-export type Connection = {
-    Disconnect: (self: Connection) -> (),
-    [any]: any,
-}
+export type Connection<C> = {
+    Disconnect: (self: Connection<C>) -> (),
+} & C
 
-export type Signal<T...> = {
-    Connect: (self: Signal<T...>, callback: Callback<T...>) -> Connection,
-    [any]: any,
-}
+export type Signal<S, C, T...> = {
+    Connect: (self: Signal<S, C, T...>, callback: Callback<T...>) -> Connection<C>,
+} & S
+
+export type RBXSignal<T...> = Signal<RBXScriptSignal, RBXScriptConnection, T...>
 
 return nil

--- a/src/init.luau
+++ b/src/init.luau
@@ -6,7 +6,8 @@ export type Callback<T> = Types.Callback<T>
 export type Handler<T...> = Types.Handler<T...>
 
 -- Trait Types
-export type Signal<T> = Types.Signal<T>
+export type Signal<T...> = Types.Signal<{ [any]: any }, { [any]: any }, T...>
+export type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Signal)
 local Instance = require(script.Instance)


### PR DESCRIPTION
This pull request updates the `observe` library to use strict typing.

Also catches/fixes a mistake in the type definitions of `Observe.Character` where it was erroneously typed as a `Model` observer instead of `Model?`.