### PR TITLE
State observation via returning callbacks

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,3 @@
+{
+    "languageMode": "strict"
+}

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,3 +1,3 @@
 [tools]
-wally = "UpliftGames/wally@0.3.1"
-rojo = "rojo-rbx/rojo@7.2.1"
+wally = "UpliftGames/wally@0.3.2"
+rojo = "rojo-rbx/rojo@7.4.4"

--- a/src/Instance.luau
+++ b/src/Instance.luau
@@ -8,6 +8,10 @@ type RBXSignal<T...> = Types.RBXSignal<T...>
 local Signal = require(script.Parent.Signal)
 local ObserveAddedRemovedSignals = Signal.AddedRemovedSignals
 
+local State = require(script.Parent.State)
+local ObserveValue = State.Value
+local ObserveClearableValue = State.ClearableValue
+
 --[=[
     @within Observe
     @param instance Instance -- The instance to observe
@@ -21,11 +25,8 @@ local ObserveAddedRemovedSignals = Signal.AddedRemovedSignals
 ]=]
 local function ObserveChild(instance: Instance, name: string, fn: Handler<Instance>): Cleanup
     local child = instance:FindFirstChild(name)
-    local cleanup = nil
 
-    if child then
-        fn(child)
-    end
+    local cleanup, onChild = ObserveClearableValue(child, fn)
 
     local function onChildAdded(added: Instance)
         -- If there is already a currently observed child, we don't need to do anything.
@@ -33,9 +34,9 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
             return
         end
 
-        -- Store the current child, call the associated function, and store the cleanup function.
+        -- Store the current child and update the clearable value.
         child = added
-        cleanup = fn(added)
+        onChild(child)
     end
 
     local function onChildRemoved(removed: Instance)
@@ -44,23 +45,9 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
             return
         end
 
-        -- Clear the current child
-        child = nil
-
-        -- Handle the previous cleanup
-        if cleanup then
-            cleanup()
-            cleanup = nil
-        end
-
-        -- Check if there is another child with the same name
-        local foundChild = instance:FindFirstChild(name)
-
-        -- If there is another child, handle it the same way as if it was added.
-        if foundChild then
-            child = foundChild
-            cleanup = fn(foundChild)
-        end
+        -- Look for another child with the same name and update the clearable value.
+        child = instance:FindFirstChild(name)
+        onChild(child)
     end
 
     local addedConnection = instance.ChildAdded:Connect(onChildAdded)
@@ -70,9 +57,7 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
         addedConnection:Disconnect()
         removedConnection:Disconnect()
 
-        if cleanup then
-            cleanup()
-        end
+        cleanup()
     end
 end
 
@@ -105,24 +90,16 @@ end
     Note: If the property is not a valid property of the instance, this will throw an error.
 ]=]
 local function ObserveProperty<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = fn((instance :: any)[name])
+    local cleanup, onChanged = ObserveValue((instance :: any)[name] :: T, fn)
 
-    local function onChanged()
-        if cleanup then
-            cleanup()
-        end
-
-        cleanup = fn((instance :: any)[name])
-    end
-
-    local connection = instance:GetPropertyChangedSignal(name):Connect(onChanged)
+    local connection = instance:GetPropertyChangedSignal(name):Connect(function()
+        onChanged((instance :: any)[name] :: T)
+    end)
 
     return function()
         connection:Disconnect()
 
-        if cleanup then
-            cleanup()
-        end
+        cleanup()
     end
 end
 
@@ -133,24 +110,16 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveAttribute<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = fn(instance:GetAttribute(name) :: T)
+    local cleanup, onChanged = ObserveValue(instance:GetAttribute(name) :: T, fn)
 
-    local function onChanged()
-        if cleanup then
-            cleanup()
-        end
-
-        cleanup = fn(instance:GetAttribute(name) :: T)
-    end
-
-    local connection = instance:GetAttributeChangedSignal(name):Connect(onChanged)
+    local connection = instance:GetAttributeChangedSignal(name):Connect(function()
+        onChanged(instance:GetAttribute(name) :: T)
+    end)
 
     return function()
         connection:Disconnect()
 
-        if cleanup then
-            cleanup()
-        end
+        cleanup()
     end
 end
 

--- a/src/Instance.luau
+++ b/src/Instance.luau
@@ -2,6 +2,8 @@ local Types = require(script.Parent.Types)
 
 type Cleanup = Types.Cleanup
 type Handler<T...> = Types.Handler<T...>
+type Signal<S, C, T...> = Types.Signal<S, C, T...>
+type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Parent.Signal)
 local ObserveAddedRemovedSignals = Signal.AddedRemovedSignals
@@ -22,10 +24,10 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
     local cleanup = nil
 
     if child then
-        (fn :: any)(child)
+        fn(child)
     end
 
-    local function onChildAdded(added)
+    local function onChildAdded(added: Instance)
         -- If there is already a currently observed child, we don't need to do anything.
         if child then
             return
@@ -33,10 +35,10 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
 
         -- Store the current child, call the associated function, and store the cleanup function.
         child = added
-        cleanup = (fn :: any)(added)
+        cleanup = fn(added)
     end
 
-    local function onChildRemoved(removed)
+    local function onChildRemoved(removed: Instance)
         -- If the removed child is not the currently observed child, it can be safely ignored.
         if removed ~= child then
             return
@@ -57,7 +59,7 @@ local function ObserveChild(instance: Instance, name: string, fn: Handler<Instan
         -- If there is another child, handle it the same way as if it was added.
         if foundChild then
             child = foundChild
-            cleanup = (fn :: any)(foundChild)
+            cleanup = fn(foundChild)
         end
     end
 
@@ -81,7 +83,7 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveChildren(instance: Instance, fn: Handler<Instance>): Cleanup
-    return ObserveAddedRemovedSignals(instance:GetChildren(), instance.ChildAdded, instance.ChildRemoved, fn)
+    return ObserveAddedRemovedSignals(instance:GetChildren(), instance.ChildAdded :: RBXSignal<Instance>, instance.ChildRemoved :: RBXSignal<Instance>, fn)
 end
 
 --[=[
@@ -91,7 +93,7 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveDescendants(instance: Instance, fn: Handler<Instance>): Cleanup
-    return ObserveAddedRemovedSignals(instance:GetDescendants(), instance.DescendantAdded, instance.DescendantRemoving, fn)
+    return ObserveAddedRemovedSignals(instance:GetDescendants(), instance.DescendantAdded :: RBXSignal<Instance>, instance.DescendantRemoving :: RBXSignal<Instance>, fn)
 end
 
 --[=[
@@ -103,14 +105,14 @@ end
     Note: If the property is not a valid property of the instance, this will throw an error.
 ]=]
 local function ObserveProperty<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = (fn :: any)(instance[name] :: T)
+    local cleanup = fn((instance :: any)[name])
 
     local function onChanged()
         if cleanup then
             cleanup()
         end
 
-        cleanup = (fn :: any)(instance[name] :: T)
+        cleanup = fn((instance :: any)[name])
     end
 
     local connection = instance:GetPropertyChangedSignal(name):Connect(onChanged)
@@ -131,14 +133,14 @@ end
     @return Cleanup -- A function that will end the observation
 ]=]
 local function ObserveAttribute<T>(instance: Instance, name: string, fn: Handler<T>): Cleanup
-    local cleanup = (fn :: any)(instance:GetAttribute(name) :: T)
+    local cleanup = fn(instance:GetAttribute(name) :: T)
 
     local function onChanged()
         if cleanup then
             cleanup()
         end
 
-        cleanup = (fn :: any)(instance:GetAttribute(name) :: T)
+        cleanup = fn(instance:GetAttribute(name) :: T)
     end
 
     local connection = instance:GetAttributeChangedSignal(name):Connect(onChanged)

--- a/src/Player.luau
+++ b/src/Player.luau
@@ -4,6 +4,7 @@ local Types = require(script.Parent.Types)
 
 type Cleanup = Types.Cleanup
 type Handler<T...> = Types.Handler<T...>
+type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Parent.Signal)
 local ObserveSetClearSignals = Signal.SetClearSignals
@@ -26,8 +27,8 @@ end
 
     Observe the character of a given player
 ]=]
-local function ObserveCharacter(player: Player, fn: Handler<Model>): Cleanup
-    return ObserveSetClearSignals(player.Character, player.CharacterAdded, player.CharacterRemoving, fn)
+local function ObserveCharacter(player: Player, fn: Handler<Model?>): Cleanup
+    return ObserveSetClearSignals(player.Character, player.CharacterAdded :: RBXSignal<Model>, player.CharacterRemoving :: RBXSignal<Model>, fn)
 end
 
 --[=[
@@ -36,10 +37,10 @@ end
 
     Observe all player character pairs in the game.
 ]=]
-local function ObservePlayerCharacters(fn: Handler<Player, Model>): Cleanup
+local function ObservePlayerCharacters(fn: Handler<Player, Model?>): Cleanup
     return ObservePlayers(function(player: Player)
-        return ObserveCharacter(player, function(character: Model)
-            return (fn :: any)(player, character)
+        return ObserveCharacter(player, function(character: Model?)
+            return fn(player, character)
         end)
     end)
 end

--- a/src/Signal.luau
+++ b/src/Signal.luau
@@ -7,29 +7,23 @@ type Callback<T> = Types.Callback<T>
 type Signal<S, C, T...> = Types.Signal<S, C, T...>
 type Connection<C> = Types.Connection<C>
 
+local State = require(script.Parent.State)
+
+local ObserveValue = State.Value
+local ObserveDistinctArray = State.DistinctArray
+
 --[=[
     Observe a signal and call a handler with whatever value the signal passes to it.
 ]=]
 local function ObserveChangedSignal<S, C, T>(value: T, changed: Signal<S, C, T>, fn: Handler<T>): Cleanup
-    -- Initially call the handler with the current value
-    local cleanup = fn(value)
-
-    local function onChanged(newValue)
-        if cleanup then
-            cleanup()
-        end
-
-        cleanup = fn(newValue)
-    end
+    local cleanup, onChanged = ObserveValue(value, fn)
 
     local connection = changed:Connect(onChanged)
 
     return function()
         connection:Disconnect()
 
-        if cleanup then
-            cleanup()
-        end
+        cleanup()
     end
 end
 
@@ -37,7 +31,6 @@ end
     Observe a set and clear signal and call a handler with whatever value the set signal passes to it.
     If the clear signal is fired, the handler will be called with nil.
 ]=]
-
 local function ObserveSetClearSignals<S1, C1, S2, C2, T>(value: T, set: Signal<S1, C1, T>, clear: Signal<S2, C2>, fn: Handler<T?>): Cleanup
     -- Initially call the handler with the current value
     local cleanup = fn(value)
@@ -72,42 +65,12 @@ local function ObserveSetClearSignals<S1, C1, S2, C2, T>(value: T, set: Signal<S
 end
 
 --[=[
-    Observe an added and removed signal and call a handler any time a value is added.
-    The handler will be called with all values that are added.
+    Observe an added and removed signal and call a handler any time a distinct value is added.
+    The handler will be called with all distinct values that are added.
     When a value is removed, the associated cleanup will be called.
 ]=]
 function ObserveAddedRemovedSignals<S1, C1, S2, C2, T>(values: {T}, added: Signal<S1, C1, T>, removed: Signal<S2, C2, T>, fn: Handler<T>): Cleanup
-    local cleanups: { [T]: Cleanup } = {}
-
-    local function onAdded(value)
-        if cleanups[value] then
-            return
-        end
-
-        local cleanup = fn(value)
-
-        if cleanup then
-            cleanups[value] = cleanup
-        end
-    end
-
-    local function onRemoved(value)
-        local cleanup = cleanups[value]
-
-        if cleanup then
-            cleanup()
-            cleanups[value] = nil
-        end
-    end
-
-    -- Initially call the handler with each current value
-    for _, value in values do
-        local cleanup = fn(value)
-
-        if cleanup then
-            cleanups[value] = cleanup
-        end
-    end
+    local cleanup, onAdded, onRemoved = ObserveDistinctArray(values, fn)
 
     -- Connect the signals
     local addedConnection = added:Connect(onAdded)
@@ -117,9 +80,7 @@ function ObserveAddedRemovedSignals<S1, C1, S2, C2, T>(values: {T}, added: Signa
         addedConnection:Disconnect()
         removedConnection:Disconnect()
 
-        for _, cleanup in cleanups do
-            cleanup()
-        end
+        cleanup()
     end
 end
 

--- a/src/Signal.luau
+++ b/src/Signal.luau
@@ -11,6 +11,7 @@ local State = require(script.Parent.State)
 
 local ObserveValue = State.Value
 local ObserveDistinctArray = State.DistinctArray
+local ObserveClearableValue = State.ClearableValue
 
 --[=[
     Observe a signal and call a handler with whatever value the signal passes to it.
@@ -32,35 +33,20 @@ end
     If the clear signal is fired, the handler will be called with nil.
 ]=]
 local function ObserveSetClearSignals<S1, C1, S2, C2, T>(value: T, set: Signal<S1, C1, T>, clear: Signal<S2, C2>, fn: Handler<T?>): Cleanup
-    -- Initially call the handler with the current value
-    local cleanup = fn(value)
-
-    local function onSet(newValue)
-        if cleanup then
-            cleanup()
-        end
-
-        cleanup = fn(newValue)
-    end
+    local cleanup, onChanged = ObserveClearableValue(value, fn)
 
     local function onClear()
-        if cleanup then
-            cleanup()
-        end
-
-        cleanup = nil
+        onChanged(nil)
     end
 
-    local setConnection = set:Connect(onSet)
+    local setConnection = set:Connect(onChanged)
     local clearConnection = clear:Connect(onClear)
 
     return function()
         setConnection:Disconnect()
         clearConnection:Disconnect()
 
-        if cleanup then
-            cleanup()
-        end
+        cleanup()
     end
 end
 

--- a/src/Signal.luau
+++ b/src/Signal.luau
@@ -4,13 +4,13 @@ type Cleanup = Types.Cleanup
 type Handler<T> = Types.Handler<T>
 type Callback<T> = Types.Callback<T>
 
-type Signal<T...> = Types.Signal<T...>
-type Connection = Types.Connection
+type Signal<S, C, T...> = Types.Signal<S, C, T...>
+type Connection<C> = Types.Connection<C>
 
 --[=[
     Observe a signal and call a handler with whatever value the signal passes to it.
 ]=]
-local function ObserveChangedSignal<T>(value: T, changed: Signal<T>, fn: Handler<T>): Cleanup
+local function ObserveChangedSignal<S, C, T>(value: T, changed: Signal<S, C, T>, fn: Handler<T>): Cleanup
     -- Initially call the handler with the current value
     local cleanup = fn(value)
 
@@ -18,7 +18,7 @@ local function ObserveChangedSignal<T>(value: T, changed: Signal<T>, fn: Handler
         if cleanup then
             cleanup()
         end
-        
+
         cleanup = fn(newValue)
     end
 
@@ -38,7 +38,7 @@ end
     If the clear signal is fired, the handler will be called with nil.
 ]=]
 
-local function ObserveSetClearSignals<T>(value: T, set: Signal<T>, clear: Signal<any>, fn: Handler<T?>): Cleanup
+local function ObserveSetClearSignals<S1, C1, S2, C2, T>(value: T, set: Signal<S1, C1, T>, clear: Signal<S2, C2>, fn: Handler<T?>): Cleanup
     -- Initially call the handler with the current value
     local cleanup = fn(value)
 
@@ -46,7 +46,7 @@ local function ObserveSetClearSignals<T>(value: T, set: Signal<T>, clear: Signal
         if cleanup then
             cleanup()
         end
-        
+
         cleanup = fn(newValue)
     end
 
@@ -76,15 +76,19 @@ end
     The handler will be called with all values that are added.
     When a value is removed, the associated cleanup will be called.
 ]=]
-function ObserveAddedRemovedSignals<T>(values: {T}, added: Signal<T>, removed: Signal<T>, fn: Handler<T>): Cleanup
-    local cleanups = {}
+function ObserveAddedRemovedSignals<S1, C1, S2, C2, T>(values: {T}, added: Signal<S1, C1, T>, removed: Signal<S2, C2, T>, fn: Handler<T>): Cleanup
+    local cleanups: { [T]: Cleanup } = {}
 
     local function onAdded(value)
         if cleanups[value] then
             return
         end
 
-        cleanups[value] = fn(value)
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        end
     end
 
     local function onRemoved(value)
@@ -98,7 +102,11 @@ function ObserveAddedRemovedSignals<T>(values: {T}, added: Signal<T>, removed: S
 
     -- Initially call the handler with each current value
     for _, value in values do
-        cleanups[value] = fn(value)
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        end
     end
 
     -- Connect the signals

--- a/src/State.luau
+++ b/src/State.luau
@@ -1,0 +1,209 @@
+local Types = require(script.Parent.Types)
+
+type Cleanup = Types.Cleanup
+type Handler<T...> = Types.Handler<T...>
+
+--[=[
+    Observe a changed callback and call a handler with whatever value the changed callback is provided.
+]=]
+local function ObserveValue<T1, T2>(value: T1, fn: Handler<T1 | T2>): (Cleanup, (T2) -> ())
+    local cleanup = fn(value)
+
+    local function onChanged(newValue: T2)
+        if cleanup then
+            cleanup()
+        end
+
+        cleanup = fn(newValue)
+    end
+
+    return function()
+        if cleanup then
+            cleanup()
+            cleanup = nil
+        end
+    end, onChanged
+end
+
+--[=[
+    Observe an added & removed callback and call a handler any time a value is added.
+    The handler will be called with all values that are added.
+    When a value is removed, the most recent cleanup will be called.
+]=]
+local function ObserveArray<T>(values: { T }, fn: Handler<T>): (Cleanup, (T) -> (), (T) -> ())
+    local cleanupsByValue: { [T]: { Cleanup } } = {}
+
+    local function onAdded(value: T)
+        local cleanups = cleanupsByValue[value]
+
+        if not cleanups then
+            cleanups = {}
+            cleanupsByValue[value] = cleanups
+        end
+
+        table.insert(cleanups, fn(value) or function() end)
+    end
+
+    local function onRemoved(value: T)
+        local cleanups = cleanupsByValue[value]
+        local cleanup = cleanups and table.remove(cleanups)
+
+        if cleanup then
+            cleanup()
+        end
+
+        if not next(cleanups) then
+            cleanupsByValue[value] = nil
+        end
+    end
+
+    -- Initially call the handler with each current value
+    for _, value in values do
+        onAdded(value)
+    end
+
+    return function()
+        for _, cleanups in cleanupsByValue do
+            for _, cleanup in cleanups do
+                cleanup()
+            end
+        end
+        table.clear(cleanupsByValue)
+    end, onAdded, onRemoved
+end
+
+--[=[
+    Observe an added & removed callback and call a handler any time a value is added.
+    The handler will be called with all distinct values that are added.
+    When a value is removed, the associated cleanup will be called.
+]=]
+local function ObserveSet<T>(values: { [T]: boolean }, fn: Handler<T>): (Cleanup, (T) -> (), (T) -> ())
+    local cleanups: { [T]: Cleanup } = {}
+
+    local function onAdded(value: T)
+        if cleanups[value] then
+            return
+        end
+
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        else
+            cleanups[value] = nil
+        end
+    end
+
+    local function onRemoved(value: T)
+        local cleanup = cleanups[value]
+
+        if cleanup then
+            cleanup()
+            cleanups[value] = nil
+        end
+    end
+
+    -- Initially call the handler with each current value
+    for value, _ in values do
+        onAdded(value)
+    end
+
+    return function()
+        for _, cleanup in cleanups do
+            cleanup()
+        end
+        table.clear(cleanups)
+    end, onAdded, onRemoved
+end
+
+--[=[
+    Observe an added & removed callback and call a handler any time a distinct (non-duplicate) value is added.
+    The handler will be called with all distinct values that are added.
+    When a value is removed, the associated cleanup will be called.
+]=]
+local function ObserveDistinctArray<T>(values: {T}, fn: Handler<T>): (Cleanup, (T) -> (), (T) -> ())
+    -- TODO: Consider converting the input array to a set and using ObserveSet
+    local cleanups: { [T]: Cleanup } = {}
+
+    local function onAdded(value: T)
+        if cleanups[value] then
+            return
+        end
+
+        local cleanup = fn(value)
+
+        if cleanup then
+            cleanups[value] = cleanup
+        else
+            cleanups[value] = nil
+        end
+    end
+
+    local function onRemoved(value: T)
+        local cleanup = cleanups[value]
+
+        if cleanup then
+            cleanup()
+            cleanups[value] = nil
+        end
+    end
+
+    -- Initially call the handler with each current value
+    for _, value in values do
+        onAdded(value)
+    end
+
+    return function()
+        for _, cleanup in cleanups do
+            cleanup()
+        end
+        table.clear(cleanups)
+    end, onAdded, onRemoved
+end
+
+--[=[
+    Observe a changed callback and call a handler with the key value pair.
+    The handler will be called with all distinct values in the map.
+    When a value is changed, the associated cleanup will be called.
+]=]
+local function ObserveMap<K, V>(values: { [K]: V }, fn: Handler<K, V>): (Cleanup, (K, V) -> ())
+    local cleanups: { [K]: Cleanup } = {}
+
+    local function onChanged(key: K, value: V)
+        local cleanup = cleanups[key]
+
+        if cleanup then
+            cleanup()
+        end
+
+        local newCleanup = fn(key, value)
+
+        if newCleanup then
+            cleanups[key] = newCleanup
+        else
+            cleanups[key] = nil
+        end
+    end
+
+    -- Initially call the handler with each current value
+    for key, value in values do
+        onChanged(key, value)
+    end
+
+    return function()
+        for _, cleanup in cleanups do
+            cleanup()
+        end
+        table.clear(cleanups)
+    end, onChanged
+end
+
+local State = {
+    Value = ObserveValue,
+    Array = ObserveArray,
+    DistinctArray = ObserveDistinctArray,
+    Set = ObserveSet,
+    Map = ObserveMap,
+}
+
+return State

--- a/src/State.luau
+++ b/src/State.luau
@@ -24,6 +24,19 @@ local function ObserveValue<T1, T2>(value: T1, fn: Handler<T1 | T2>): (Cleanup, 
         end
     end, onChanged
 end
+--[=[
+    Observe a changed callback and call a handler with whatever non-nil value the changed callback is provided.
+    When the value is nil or the cleanup callback is called the handler will not be called.
+]=]
+local function ObserveClearableValue<T1, T2>(value: T1?, fn: Handler<T1 | T2>): (Cleanup, (T2?) -> ())
+    return ObserveValue(value, function(newValue: (T1 | T2)?)
+        if newValue == nil then
+            return
+        end
+
+        return fn(newValue)
+    end)
+end
 
 --[=[
     Observe an added & removed callback and call a handler any time a value is added.
@@ -200,6 +213,7 @@ end
 
 local State = {
     Value = ObserveValue,
+    ClearableValue = ObserveClearableValue,
     Array = ObserveArray,
     DistinctArray = ObserveDistinctArray,
     Set = ObserveSet,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -5,14 +5,14 @@ export type Callback<T...> = (T...) -> ()
 export type Handler<T...> = (T...) -> Cleanup?
 
 -- Trait Types
-export type Connection = {
-    Disconnect: (self: Connection) -> (),
-    [any]: any,
-}
+export type Connection<C> = {
+    Disconnect: (self: Connection<C>) -> (),
+} & C
 
-export type Signal<T...> = {
-    Connect: (self: Signal<T...>, callback: Callback<T...>) -> Connection,
-    [any]: any,
-}
+export type Signal<S, C, T...> = {
+    Connect: (self: Signal<S, C, T...>, callback: Callback<T...>) -> Connection<C>,
+} & S
+
+export type RBXSignal<T...> = Signal<RBXScriptSignal, RBXScriptConnection, T...>
 
 return nil

--- a/src/init.luau
+++ b/src/init.luau
@@ -23,6 +23,7 @@ local Observe = {
 
     -- State Adapters
     Value = State.Value,
+    ClearableValue = State.ClearableValue,
     Array = State.Array,
     DistinctArray = State.DistinctArray,
     Set = State.Set,

--- a/src/init.luau
+++ b/src/init.luau
@@ -13,12 +13,20 @@ local Signal = require(script.Signal)
 local Instance = require(script.Instance)
 local Player = require(script.Player)
 local Collection = require(script.Collection)
+local State = require(script.State)
 
 local Observe = {
     -- Signal Adapters
     ChangedSignal = Signal.ChangedSignal,
     SetClearSignals = Signal.SetClearSignals,
     AddedRemovedSignal = Signal.AddedRemovedSignals,
+
+    -- State Adapters
+    Value = State.Value,
+    Array = State.Array,
+    DistinctArray = State.DistinctArray,
+    Set = State.Set,
+    Map = State.Map,
 
     -- Instance Management
     Children = Instance.Children,

--- a/src/init.luau
+++ b/src/init.luau
@@ -6,7 +6,8 @@ export type Callback<T> = Types.Callback<T>
 export type Handler<T...> = Types.Handler<T...>
 
 -- Trait Types
-export type Signal<T> = Types.Signal<T>
+export type Signal<T...> = Types.Signal<{ [any]: any }, { [any]: any }, T...>
+export type RBXSignal<T...> = Types.RBXSignal<T...>
 
 local Signal = require(script.Signal)
 local Instance = require(script.Instance)


### PR DESCRIPTION
Based on #2

This pull request aims to provide big usability improvements to the `observe` library by introducing new callback based APIs for representing raw data.

The new APIs reduce the amount of boilerplate required to write observers for things like Fusion states, which in the current version of `observe` requires extra intermediate Signal objects to be instantiated.

- Implements new observer code by using callbacks returned from `observe` instead of signals passed to `observe`.
- Re-implements the existing signal based code to use the callback-based APIs, by binding returned callbacks to the signals.
- Adds the following `State` observers:
  - Adds `Value`, which returns a `cleanup` & `onChanged` function. The `onChanged` function, when called, will update the state of the observer.
  - Adds `ClearableValue`, which is almost identical to `Value`, except a value of `nil` is treated as a clear and does not invoke the handler (but does invoke cleanup).
    - This is shorthand for an observer with a guard clause on `nil` values, which is a common pattern. It is used by the existing `Child` and `SetClearSignals` observers.
    - It might be desirable to rename this to `Clearable`.
  - Adds `Array` for unordered arrays, which returns a `cleanup`, `onAdded`, and `onRemoved`.
    - Removals of duplicate values follow the ordering of a stack. I expect that, where order matters, this is typically the most sensible behaviour.
  - Adds `Set` for sets, returns a `cleanup`, `onAdded`, and `onRemoved` callback.
    - Note: `onAdded` will currently *NOT* invoke cleanup & re-invoke the handler on re-insertion of a value already present in the set. I am currently unsure if this is good in practice. The alternative would be more in-line with what existing observer APIs do even if it's a bit wasteful.
  - Adds `DistinctArray` for arrays with distinct (unique, non-duplicate) items. Identical to `Set`, other than its initial value being an array instead of a set.
    - It is valid to pass an array that contains duplicate values to begin with, the observer naturally conforms to appropriate expectations here.
    - Note: Like with `Set`, no re-invocation on re-insertion.
    - Additional note: `DistinctArray` currently has duplicated code used in `Set`. It might be desirable to remove `DistinctArray` and expect users to use `Set` themselves, or to alternatively implement `DistinctArray` using `Set` under the hood, simply passing in a blank array and adding the values using the callbacks. Should resolve this after #2 is either merged or rejected.
  - Adds `Map` for maps, which returns a `cleanup` & `onChanged` function. The `onChanged` function takes a key and value argument. The handler also takes *both* a key *and* a value. Otherwise, works exactly how you would expect.